### PR TITLE
Replace tiny-lr with mini-lr

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "connect-livereload": "^0.4.0",
     "gulp-util": "^2.2.19",
     "isarray": "0.0.1",
+    "mini-lr": "^0.1.8",
     "node.extend": "^1.0.10",
     "open": "^0.0.5",
     "proxy-middleware": "^0.5.0",

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ var connect = require('connect');
 var serveStatic = require('serve-static');
 var connectLivereload = require('connect-livereload');
 var proxy = require('proxy-middleware');
-var tinyLr = require('tiny-lr');
+var miniLr = require('mini-lr');
 var watch = require('watch');
 var fs = require('fs');
 var serveIndex = require('serve-index');
@@ -112,19 +112,19 @@ module.exports = function(options) {
 
     if (config.https) {
       if (config.https.pfx) {
-        lrServer = tinyLr({
+        lrServer = miniLr({
           pfx: fs.readFileSync(config.https.pfx),
           passphrase: config.https.passphrase
         });
       }
       else {
-        lrServer = tinyLr({
+        lrServer = miniLr({
           key: fs.readFileSync(config.https.key || __dirname + '/../ssl/dev-key.pem'),
           cert: fs.readFileSync(config.https.cert || __dirname + '/../ssl/dev-cert.pem')
         });
       }
     } else {
-      lrServer = tinyLr();
+      lrServer = miniLr();
     }
 
     lrServer.listen(config.livereload.port, config.host);


### PR DESCRIPTION
Tiny-lr has an issue with npm v3's flat module directory, reference [here](https://github.com/mklabs/tiny-lr/issues/91).

However, the project hasn't been updated in quite some time, and the maintainers have a history of abandoning it.  In order to unblock npm v3 users, I've forked the project and released it under the name `mini-lr`. You can find the new repository [here](http://jhawk.co/mini-lr). I recommend updating your project to use the latest release in order to enable npm v3 usage. Thanks!
