### PR TITLE
Fix path separator issue on Windows vs Linux

### DIFF
--- a/src/mock.js
+++ b/src/mock.js
@@ -18,7 +18,7 @@ module.exports = function(req, res, next){
 
   // 查找本地是否存在这个文件
   fileNames.forEach(function(name) {
-      if (fullName === name) {
+      if (fullName === name.replace(path.sep, '/')) {
           hasFile = true;
       }
   });

--- a/src/mock.js
+++ b/src/mock.js
@@ -12,7 +12,7 @@ module.exports = function(req, res, next){
   var dir = path.join(CWD, './data/');
   var fileNames = rd.readSync(dir)
     .filter(function(x) {return x.split('.')[1] === 'json'})
-    .map(function(x) {return x.split('/data/')[1];})
+    .map(function(x) {return x.split(path.sep + 'data' + path.sep)[1];})
     .map(function(x) {return '/' + x.split('.')[0];});
   var hasFile = false;
 


### PR DESCRIPTION
On Windows, the hardcoded `/` directory separator caused the following error. Using `path.sep` fixes the issue.

```
[17:43:42] Using gulpfile D:\Dev\testing\gulp-mock-server\gulpfile.js
[17:43:42] Starting 'mock'...
[17:43:42] Webserver started at http://localhost:8090
TypeError: Cannot call method 'split' of undefined
    at D:\Dev\testing\gulp-mock-server\node_modules\gulp-mock-server\src\mock.js:16:38
    at Array.map (native)
    at module.exports (D:\Dev\testing\gulp-mock-server\node_modules\gulp-mock-server\src\mock.js:16:6)
    at call (D:\Dev\testing\gulp-mock-server\node_modules\gulp-mock-server\node_modules\connect\index.js:239:7)
    at next (D:\Dev\testing\gulp-mock-server\node_modules\gulp-mock-server\node_modules\connect\index.js:183:5)
    at D:\Dev\testing\gulp-mock-server\node_modules\gulp-mock-server\node_modules\connect-query\index.js:8:5
    at call (D:\Dev\testing\gulp-mock-server\node_modules\gulp-mock-server\node_modules\connect\index.js:239:7)
    at next (D:\Dev\testing\gulp-mock-server\node_modules\gulp-mock-server\node_modules\connect\index.js:183:5)
    at jsonParser (D:\Dev\testing\gulp-mock-server\node_modules\gulp-mock-server\node_modules\body-parser\lib\types\json.js:100:40)
    at call (D:\Dev\testing\gulp-mock-server\node_modules\gulp-mock-server\node_modules\connect\index.js:239:7)
TypeError: Cannot call method 'split' of undefined
    at D:\Dev\testing\gulp-mock-server\node_modules\gulp-mock-server\src\mock.js:16:38
    at Array.map (native)
    at module.exports (D:\Dev\testing\gulp-mock-server\node_modules\gulp-mock-server\src\mock.js:16:6)
    at call (D:\Dev\testing\gulp-mock-server\node_modules\gulp-mock-server\node_modules\connect\index.js:239:7)
    at next (D:\Dev\testing\gulp-mock-server\node_modules\gulp-mock-server\node_modules\connect\index.js:183:5)
    at D:\Dev\testing\gulp-mock-server\node_modules\gulp-mock-server\node_modules\connect-query\index.js:8:5
    at call (D:\Dev\testing\gulp-mock-server\node_modules\gulp-mock-server\node_modules\connect\index.js:239:7)
    at next (D:\Dev\testing\gulp-mock-server\node_modules\gulp-mock-server\node_modules\connect\index.js:183:5)
    at jsonParser (D:\Dev\testing\gulp-mock-server\node_modules\gulp-mock-server\node_modules\body-parser\lib\types\json.js:100:40)
    at call (D:\Dev\testing\gulp-mock-server\node_modules\gulp-mock-server\node_modules\connect\index.js:239:7)
```
